### PR TITLE
Update generateCNAME() to prevent empty list

### DIFF
--- a/Sources/CNAMEPublishPlugin/CNAMEPublishPlugin.swift
+++ b/Sources/CNAMEPublishPlugin/CNAMEPublishPlugin.swift
@@ -11,7 +11,7 @@ import Publish
 // MARK: - CNAME_Error
 
 /// Supported errors that can occur with CNAME file generation.
-enum CNAME_Error: LocalizedError, CustomStringConvertible {
+enum CNAMEGenerationError: LocalizedError, CustomStringConvertible {
     
     /// The list of provided domain names is empty.
     case listEmpty
@@ -57,13 +57,13 @@ public extension Plugin {
     /// - Parameter domainNames: A list of domain names to use for the website.
     ///
     /// - Throws:
-    ///      - `CNAME_Error.listEmpty` if the provided list is empty.
-    ///      - `CNAME_Error.containsEmptyString` if one or more of the provided domain names are empty strings.
+    ///      - `CNAMEGenerationError.listEmpty` if the provided list is empty.
+    ///      - `CNAMEGenerationError.containsEmptyString` if one or more of the provided domain names are empty strings.
     static func generateCNAME(with domainNames: [String]) -> Self {
         Plugin(name: "Generate CNAME from provided domain names") { context in
-            guard !domainNames.isEmpty else { throw CNAME_Error.listEmpty }
+            guard !domainNames.isEmpty else { throw CNAMEGenerationError.listEmpty }
             
-            guard domainNames.allSatisfy({ !$0.isEmpty }) else { throw CNAME_Error.containsEmptyString }
+            guard domainNames.allSatisfy({ !$0.isEmpty }) else { throw CNAMEGenerationError.containsEmptyString }
             
             let fileContent = domainNames.joined(separator: "\n")
             
@@ -81,7 +81,7 @@ public extension Plugin {
             
             let fileContent = try file.readAsString()
             
-            guard !fileContent.isEmpty else { throw CNAME_Error.listEmpty }
+            guard !fileContent.isEmpty else { throw CNAMEGenerationError.listEmpty }
             
             try context.copyFileToOutput(from: "Resources/CNAME")
         }

--- a/Sources/CNAMEPublishPlugin/CNAMEPublishPlugin.swift
+++ b/Sources/CNAMEPublishPlugin/CNAMEPublishPlugin.swift
@@ -5,7 +5,31 @@
 */
 
 import Files
+import Foundation
 import Publish
+
+// MARK: - CNAME_Error
+
+/// Supported errors that can occur with CNAME file generation.
+public enum CNAME_Error: LocalizedError {
+    
+    /// The list of provided domain names is empty.
+    case listEmpty
+    
+    /// In the list of provided domain names, there is an empty string.
+    case containsEmptyString
+    
+    public var localizedDescription: String {
+        switch self {
+        case .listEmpty:
+            return "The provided list of domain names are empty. At least one domain name is required for file generation."
+        case .containsEmptyString:
+            return "One of the provided domain names is an empty string."
+        }
+    }
+}
+
+// MARK: - Plugin
 
 public extension Plugin {
     
@@ -23,10 +47,16 @@ public extension Plugin {
         }
     }
     
+    static func generateCNAME(with domainNames: [String]) -> Self {
+        Plugin(name: "Generate CNAME from provided domain names") { context in
+            guard domainNames.allSatisfy({ !$0.isEmpty }) else { return }
+        }
+    }
+    
     /// Returns a plugin that copies a custom domain name file from the website's resources directory to the website's
     /// output directory.
     static func addCNAME() -> Self {
-        Plugin(name: "Generate CNAME for custom domain names") { context in
+        Plugin(name: "Generate CNAME from existing CNAME file in the Resources directory") { context in
             let file = try context.file(at: "Resources/CNAME")
             
             let fileContent = try file.readAsString()

--- a/Sources/CNAMEPublishPlugin/CNAMEPublishPlugin.swift
+++ b/Sources/CNAMEPublishPlugin/CNAMEPublishPlugin.swift
@@ -11,7 +11,7 @@ import Publish
 // MARK: - CNAME_Error
 
 /// Supported errors that can occur with CNAME file generation.
-public enum CNAME_Error: LocalizedError {
+enum CNAME_Error: LocalizedError, CustomStringConvertible {
     
     /// The list of provided domain names is empty.
     case listEmpty
@@ -19,7 +19,7 @@ public enum CNAME_Error: LocalizedError {
     /// In the list of provided domain names, there is an empty string.
     case containsEmptyString
     
-    public var localizedDescription: String {
+    var description: String {
         switch self {
         case .listEmpty:
             return "The provided list of domain names are empty. At least one domain name is required for file generation."
@@ -27,28 +27,32 @@ public enum CNAME_Error: LocalizedError {
             return "One of the provided domain names is an empty string."
         }
     }
+    
+    var localizedDescription: String { description }
+    var errorDescription: String? { description }
 }
 
 // MARK: - Plugin
 
 public extension Plugin {
     
-    /// Returns a plugin that creates a custom domain name file from a list of domain names and adds it to the website's
-    /// output directory.
+    /// Returns a plugin that creates a custom domain name file from a given domain name as well as a list of other
+    /// domain names and adds it to the website's output directory.
     ///
-    /// - Parameter domainNames: A list of domain names to use for the website.
+    /// - Parameters:
+    ///   - domainName: The domain name that will be first in the file.
+    ///   - otherDomainNames: A list of other domain names that will come after `domainName`.
+    ///
+    /// - Throws: See [generateCNAME(with domainNames: [String])](x-source-tag://throwingMethod) for errors that can be
+    ///           thrown.
     static func generateCNAME(with domainName: String, _ otherDomainNames: String...) -> Self {
-        Plugin(name: "Generate CNAME for custom domain names") { context in
-            let allDomainNames = CollectionOfOne(domainName) + otherDomainNames
-            
-            let fileContent = allDomainNames.joined(separator: "\n")
-            
-            try context.createOutputFile(at: "CNAME").write(fileContent)
-        }
+        return generateCNAME(with: CollectionOfOne(domainName) + otherDomainNames)
     }
     
     /// Returns a plugin that creates a custom domain name file from a list of domain names and adds it to the website's
     /// output directory.
+    ///
+    /// - Tag: throwingMethod
     ///
     /// - Parameter domainNames: A list of domain names to use for the website.
     ///

--- a/Sources/CNAMEPublishPlugin/CNAMEPublishPlugin.swift
+++ b/Sources/CNAMEPublishPlugin/CNAMEPublishPlugin.swift
@@ -13,11 +13,11 @@ public extension Plugin {
     /// output directory.
     ///
     /// - Parameter domainNames: A list of domain names to use for the website.
-    static func generateCNAME(with domainNames: String...) -> Self {
+    static func generateCNAME(with domainName: String, _ otherDomainNames: String...) -> Self {
         Plugin(name: "Generate CNAME for custom domain names") { context in
-            guard !domainNames.isEmpty else { return }
+            let allDomainNames = CollectionOfOne(domainName) + otherDomainNames
             
-            let fileContent = domainNames.joined(separator: "\n")
+            let fileContent = allDomainNames.joined(separator: "\n")
             
             try context.createOutputFile(at: "CNAME").write(fileContent)
         }

--- a/Sources/CNAMEPublishPlugin/CNAMEPublishPlugin.swift
+++ b/Sources/CNAMEPublishPlugin/CNAMEPublishPlugin.swift
@@ -47,21 +47,37 @@ public extension Plugin {
         }
     }
     
+    /// Returns a plugin that creates a custom domain name file from a list of domain names and adds it to the website's
+    /// output directory.
+    ///
+    /// - Parameter domainNames: A list of domain names to use for the website.
+    ///
+    /// - Throws:
+    ///      - `CNAME_Error.listEmpty` if the provided list is empty.
+    ///      - `CNAME_Error.containsEmptyString` if one or more of the provided domain names are empty strings.
     static func generateCNAME(with domainNames: [String]) -> Self {
         Plugin(name: "Generate CNAME from provided domain names") { context in
-            guard domainNames.allSatisfy({ !$0.isEmpty }) else { return }
+            guard !domainNames.isEmpty else { throw CNAME_Error.listEmpty }
+            
+            guard domainNames.allSatisfy({ !$0.isEmpty }) else { throw CNAME_Error.containsEmptyString }
+            
+            let fileContent = domainNames.joined(separator: "\n")
+            
+            try context.createOutputFile(at: "CNAME").write(fileContent)
         }
     }
     
     /// Returns a plugin that copies a custom domain name file from the website's resources directory to the website's
     /// output directory.
+    ///
+    /// - Throws: `CNAME_Error.listEmpty` if the provided list from the file is empty.
     static func addCNAME() -> Self {
         Plugin(name: "Generate CNAME from existing CNAME file in the Resources directory") { context in
             let file = try context.file(at: "Resources/CNAME")
             
             let fileContent = try file.readAsString()
             
-            guard !fileContent.isEmpty else { return }
+            guard !fileContent.isEmpty else { throw CNAME_Error.listEmpty }
             
             try context.copyFileToOutput(from: "Resources/CNAME")
         }

--- a/Tests/CNAMEPublishPluginTests/CNAMEPublishPluginTests.swift
+++ b/Tests/CNAMEPublishPluginTests/CNAMEPublishPluginTests.swift
@@ -101,7 +101,7 @@ final class CNAMEPublishPluginTests: XCTestCase {
         ) { error in
             let errorDescription = (error as? PublishingError)?.errorDescription ?? ""
             
-            XCTAssertTrue(errorDescription.contains(CNAME_Error.containsEmptyString.localizedDescription))
+            XCTAssertTrue(errorDescription.contains(CNAMEGenerationError.containsEmptyString.localizedDescription))
         }
     }
     
@@ -114,7 +114,7 @@ final class CNAMEPublishPluginTests: XCTestCase {
         ) { error in
             let errorDescription = (error as? PublishingError)?.errorDescription ?? ""
             
-            XCTAssertTrue(errorDescription.contains(CNAME_Error.listEmpty.localizedDescription))
+            XCTAssertTrue(errorDescription.contains(CNAMEGenerationError.listEmpty.localizedDescription))
         }
     }
         
@@ -146,7 +146,7 @@ final class CNAMEPublishPluginTests: XCTestCase {
         ) { error in
             let errorDescription = (error as? PublishingError)?.errorDescription ?? ""
             
-            XCTAssertTrue(errorDescription.contains(CNAME_Error.listEmpty.localizedDescription))
+            XCTAssertTrue(errorDescription.contains(CNAMEGenerationError.listEmpty.localizedDescription))
         }
     }
 }

--- a/Tests/CNAMEPublishPluginTests/CNAMEPublishPluginTests.swift
+++ b/Tests/CNAMEPublishPluginTests/CNAMEPublishPluginTests.swift
@@ -32,7 +32,7 @@ private struct TestWebsite: Website {
 
 final class CNAMEPublishPluginTests: XCTestCase {
     
-    // MARK: - Private Class Properties
+    // MARK: - Properties
     
     private static var testDirPath: Path {
         let sourceFileURL = URL(fileURLWithPath: #file)
@@ -40,14 +40,13 @@ final class CNAMEPublishPluginTests: XCTestCase {
         return Path(sourceFileURL.deletingLastPathComponent().path)
     }
     
-    // MARK: - Internal Class Properties
-    
     static var allTests = [
-        ("testGeneratedCNAME_WithDomainNames", testGenerateCNAME),
-        ("testGeneratedCNAME_WithFile", testAddCNAME)
+        ("testGeneratedCNAME", testGenerateCNAME),
+        ("testGenerateCNAME_WhenDomainNameIsEmpty", testGenerateCNAME_WhenDomainNameIsEmpty),
+        ("testGenerateCNAME_WhenListOfDomainNamesAreEmpty", testGenerateCNAME_WhenListOfDomainNamesAreEmpty),
+        ("testAddCNAME", testAddCNAME),
+        ("testAddCNAME_WhenFileIsEmpty", testAddCNAME_WhenFileIsEmpty)
     ]
-    
-    // MARK: - Private Instance Properties
     
     private var outputFolder: Folder? {
         try? Folder(path: Self.testDirPath.appendingComponent("Output").absoluteString)
@@ -78,7 +77,7 @@ final class CNAMEPublishPluginTests: XCTestCase {
         try? Folder(path: Self.testDirPath.appendingComponent(".publish").absoluteString).delete()
     }
     
-    // MARK: - Tests
+    // MARK: - Test(s)
     
     func testGenerateCNAME() throws {
         try TestWebsite().publish(at: Self.testDirPath, using: [
@@ -93,6 +92,32 @@ final class CNAMEPublishPluginTests: XCTestCase {
         """)
     }
     
+    func testGenerateCNAME_WhenDomainNameIsEmpty() {
+        XCTAssertThrowsError(
+            try TestWebsite().publish(
+                at: Self.testDirPath,
+                using: [.installPlugin(.generateCNAME(with: ""))]
+            )
+        ) { error in
+            let errorDescription = (error as? PublishingError)?.errorDescription ?? ""
+            
+            XCTAssertTrue(errorDescription.contains(CNAME_Error.containsEmptyString.localizedDescription))
+        }
+    }
+    
+    func testGenerateCNAME_WhenListOfDomainNamesAreEmpty() {
+        XCTAssertThrowsError(
+            try TestWebsite().publish(
+                at: Self.testDirPath,
+                using: [.installPlugin(.generateCNAME(with: []))]
+            )
+        ) { error in
+            let errorDescription = (error as? PublishingError)?.errorDescription ?? ""
+            
+            XCTAssertTrue(errorDescription.contains(CNAME_Error.listEmpty.localizedDescription))
+        }
+    }
+        
     func testAddCNAME() throws {
         try resourcesFolder?
             .createFile(named: "CNAME")
@@ -108,5 +133,20 @@ final class CNAMEPublishPluginTests: XCTestCase {
         test.io
         www.test.io
         """)
+    }
+    
+    func testAddCNAME_WhenFileIsEmpty() throws {
+        try resourcesFolder?.createFile(named: "CNAME")
+        
+        XCTAssertThrowsError(
+            try TestWebsite().publish(
+                at: Self.testDirPath,
+                using: [.installPlugin(.addCNAME())]
+            )
+        ) { error in
+            let errorDescription = (error as? PublishingError)?.errorDescription ?? ""
+            
+            XCTAssertTrue(errorDescription.contains(CNAME_Error.listEmpty.localizedDescription))
+        }
     }
 }


### PR DESCRIPTION
This PR removes the possibility of the user specifying an empty list of CNAME domains. (Please also check the PR locally because I made this change using GitHub's online editor.)